### PR TITLE
Add API documentation with drf-yasg v1.20.0

### DIFF
--- a/server/config/api_router.py
+++ b/server/config/api_router.py
@@ -16,11 +16,11 @@ router.register("records", RecordViewSet)
 router.register("releases", ReleaseViewSet)
 router.register("buyers", BuyerViewSet)
 
-
 app_name = "api"
 urlpatterns = router.urls
 
 urlpatterns += [
     path("tenders/", include("ocds_tender.urls")),
     path("outputs/", include("ocds_release.urls")),
+    path('docs/', include("api_doc.urls")),
 ]

--- a/server/config/settings/base.py
+++ b/server/config/settings/base.py
@@ -67,6 +67,8 @@ THIRD_PARTY_APPS = [
     'django_cron',
     "crispy_forms",
     "allauth",
+    "allauth.account",
+    "allauth.socialaccount",
     "rest_framework",
     "rest_framework.authtoken",
     "corsheaders",
@@ -275,9 +277,9 @@ ACCOUNT_ALLOW_REGISTRATION = env.bool("DJANGO_ACCOUNT_ALLOW_REGISTRATION", True)
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
 ACCOUNT_AUTHENTICATION_METHOD = "username"
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
-ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_EMAIL_REQUIRED = False
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
-ACCOUNT_EMAIL_VERIFICATION = "mandatory"
+ACCOUNT_EMAIL_VERIFICATION = "optional"
 # https://django-allauth.readthedocs.io/en/latest/configuration.html
 ACCOUNT_ADAPTER = "transparencyportal.users.adapters.AccountAdapter"
 # https://django-allauth.readthedocs.io/en/latest/configuration.html

--- a/server/config/settings/local.py
+++ b/server/config/settings/local.py
@@ -62,3 +62,5 @@ INSTALLED_APPS += ["django_extensions"]  # noqa F405
 
 # Your stuff...
 # ------------------------------------------------------------------------------
+INSTALLED_APPS += ["drf_yasg"]
+INSTALLED_APPS += ["api_doc"]

--- a/server/requirements/base.txt
+++ b/server/requirements/base.txt
@@ -23,8 +23,7 @@ lxml==4.6.3
 django-cron==0.5.1
 pycodestyle==2.7.0
 markdown==3.3.4
-django-rest-swagger==2.2.0
+drf-yasg==1.20.0
 geopy==2.2.0
 pdfkit==0.6.1
 xlrd==2.0.1
-

--- a/server/transparencyportal/api_doc/urls.py
+++ b/server/transparencyportal/api_doc/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path, re_path
+
+from api_doc.views import schema_view
+
+urlpatterns = [
+   re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
+   re_path(r'swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+   re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc-ui'),
+]

--- a/server/transparencyportal/api_doc/views.py
+++ b/server/transparencyportal/api_doc/views.py
@@ -1,0 +1,11 @@
+from rest_framework import permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+schema_view = get_schema_view(
+   openapi.Info(
+      title="API Documentation",
+      default_version="v1"
+   ),
+   permission_classes=(permissions.AllowAny,),
+)

--- a/server/transparencyportal/templates/pages/home.html
+++ b/server/transparencyportal/templates/pages/home.html
@@ -1,1 +1,11 @@
 {% extends "base.html" %}
+
+{% if debug %}
+{% block content %}
+<p>API Documentation can be viewed at :</p>
+<ul>
+    <li><a href="{% url 'api:schema-swagger-ui' %}">Swagger UI</a></li>
+    <li><a href="{% url 'api:schema-redoc-ui' %}">Redoc UI</a></li>
+</ul>
+{% endblock %}
+{% endif %}


### PR DESCRIPTION
As django-rest-swagger is deprecated, drf-yasg replaces it